### PR TITLE
Activer l'automerge sur Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,17 @@
     "extends": ["github>1024pix/renovate-config:default.json"],
     "enabled": true,
     "includeForks": true,
+    "packageRules": [
+        {
+            "description": "autoMerge metabase upgrade",
+            "matchDatasources": ["github-tags"],
+            "matchManagers": [ "regex" ],
+            "matchPackageNames": ["metabase/metabase"],
+            "matchUpdateTypes": ["minor", "patch"],
+            "addLabels": ["renovate/automerge"],
+            "automerge": true
+        }
+    ],
     "regexManagers": [
         {
             "fileMatch": ["^bin/version$"],


### PR DESCRIPTION
## :unicorn: Problème
Les PR Renovate doivent être mergées à la main sans plus value

## :robot: Proposition
Les merger automatiquement

## :100: Pour tester
Merger et vérifier que renovate merge ses PR lors de son prochain passage