### PR TITLE
[TECH] Utiliser la datasource github-releases pour les mises à jour

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
                 "^(?<currentValue>\\S+)\\n?$"
             ],
             "depNameTemplate": "metabase/metabase",
-            "datasourceTemplate": "github-tags",
+            "datasourceTemplate": "github-releases",
             "extractVersionTemplate": "v(?<version>.*)"
         }
     ]


### PR DESCRIPTION
## 🔆 Problème
Aujourd'hui, on se base sur les tags github de metabase plutôt que sur les releases pour savoir si l'on doit faire une mise à jour. 

## ⛱️ Proposition
Utiliser la datasource github-releases pour les mises à jour